### PR TITLE
fix(router): guard latency-aware routing against empty candidate set

### DIFF
--- a/src/router/strategies.py
+++ b/src/router/strategies.py
@@ -228,6 +228,16 @@ class LatencyAwareStrategy(RoutingStrategy):
             for candidate in self._model_catalog.values()
             if signals.domain_tag in candidate.supports_domains
         ]
+        if not eligible_candidates:
+            highest_quality = max(
+                self._model_catalog.values(),
+                key=lambda candidate: candidate.quality_score,
+            )
+            return self._decision(
+                highest_quality.model,
+                "no model supports requested domain; "
+                "latency-aware fell back to highest-quality model",
+            )
         selected_candidate = min(
             eligible_candidates,
             key=lambda candidate: (

--- a/tests/test_latency_aware_fallback.py
+++ b/tests/test_latency_aware_fallback.py
@@ -1,0 +1,60 @@
+"""Regression tests for latency-aware routing with restricted catalogs."""
+
+from router.schemas import (
+    ChatMessage,
+    DomainTag,
+    LatencyRequirement,
+    ModelCandidate,
+    RouterRequest,
+    TaskSignals,
+)
+from router.strategies import LatencyAwareStrategy, LatencyStats
+
+
+def _general_only_catalog() -> dict[str, ModelCandidate]:
+    """Build a catalog whose models only support the general domain."""
+    return {
+        "gpt-4o-mini": ModelCandidate(
+            model="gpt-4o-mini",
+            provider="openai",
+            quality_score=0.82,
+            input_cost_per_1k=0.00015,
+            output_cost_per_1k=0.0006,
+            supports_domains={DomainTag.GENERAL},
+        ),
+        "kimi-k2": ModelCandidate(
+            model="kimi-k2",
+            provider="moonshot",
+            quality_score=0.90,
+            input_cost_per_1k=0.0005,
+            output_cost_per_1k=0.002,
+            supports_domains={DomainTag.GENERAL},
+        ),
+    }
+
+
+def test_latency_aware_falls_back_when_no_model_supports_domain() -> None:
+    """Latency-aware routing should not crash when no candidate supports the domain.
+
+    A custom catalog that omits a domain previously raised an opaque
+    ``ValueError`` from ``min()`` over an empty sequence. It should instead fall
+    back to the highest-quality model, mirroring ``CostOptimalStrategy``.
+    """
+    catalog = _general_only_catalog()
+    strategy = LatencyAwareStrategy(catalog, LatencyStats())
+    request = RouterRequest(
+        request_id="req-medical",
+        messages=[ChatMessage(content="Assess patient symptoms.")],
+    )
+    signals = TaskSignals(
+        complexity_score=0.5,
+        domain_tag=DomainTag.MEDICAL,
+        latency_requirement=LatencyRequirement.REALTIME,
+        token_budget=4096,
+        prompt_tokens_estimate=8,
+    )
+
+    decision = strategy.choose(request, signals)
+
+    assert decision.chosen_model == "kimi-k2"
+    assert "highest-quality" in decision.rationale


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`LatencyAwareStrategy.choose()` filters the model catalog down to candidates that support the request's `domain_tag`, then calls `min()` over that list to pick the lowest-cost/latency option. It never checks whether the filtered list is empty.

`NexusRouter` accepts a `model_catalog` override (a documented extension point). If a custom catalog omits a domain (e.g. no model declares `supports_domains={MEDICAL}`), the filtered list is empty and `min()` raises an opaque `ValueError: min() iterable argument is empty` at request time.

`CostOptimalStrategy` already guards the analogous "no feasible candidate" case by falling back to the highest-quality model. This change makes `LatencyAwareStrategy` consistent: when no model supports the requested domain, it falls back to the highest-quality model in the catalog with a clear rationale instead of crashing.

## Changes

- `src/router/strategies.py`: add an empty-candidate guard in `LatencyAwareStrategy.choose()` that returns the highest-quality model with an explanatory rationale.
- `tests/test_latency_aware_fallback.py`: new regression test using a general-only catalog and a `MEDICAL` request. It reproduces the crash (`ValueError`) on the pre-fix code and passes after the fix.

## Validation

Run in a Python 3.12 virtualenv created from `pip install -e ".[dev]"`:

- `ruff check src/ tests/` — all checks passed
- `mypy src/` — success, no issues in 32 source files
- `pytest tests/ -v` — 12 passed (was 11; +1 new regression test)

Confirmed the new test fails on `main` (without the source fix) with `ValueError: min() iterable argument is empty`, and passes with the fix.

Behavior with the default catalog is unchanged: every default domain already has at least one supporting model, so the new branch is only taken by catalogs that omit a domain.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

