### PR TITLE
test(router): cover rule-based, classifier, and cost-optimal decision paths

### DIFF
--- a/tests/test_strategy_coverage.py
+++ b/tests/test_strategy_coverage.py
@@ -1,0 +1,121 @@
+"""Coverage for routing-strategy and classifier decision paths.
+
+These exercise decision branches that the existing suite does not cover:
+the rule-based priority matrix, the classifier complexity tiers, the
+cost-optimal quality-floor fallback, and complexity-score monotonicity.
+"""
+
+from classifier.complexity import LogisticComplexityClassifier
+from classifier.features import extract_prompt_features
+from router.config import default_model_catalog
+from router.schemas import (
+    ChatMessage,
+    DomainTag,
+    LatencyRequirement,
+    RouterRequest,
+    RoutingStrategyName,
+    TaskSignals,
+)
+from router.strategies import (
+    ClassifierStrategy,
+    CostOptimalStrategy,
+    RuleBasedStrategy,
+)
+
+
+def _request(content: str = "Hello", requested_model: str | None = None) -> RouterRequest:
+    """Build a minimal router request for strategy unit tests."""
+    return RouterRequest(
+        request_id="req-test",
+        messages=[ChatMessage(content=content)],
+        requested_model=requested_model,
+    )
+
+
+def _signals(
+    complexity_score: float,
+    domain_tag: DomainTag,
+    latency_requirement: LatencyRequirement = LatencyRequirement.REALTIME,
+) -> TaskSignals:
+    """Build task signals with explicit complexity, domain, and latency."""
+    return TaskSignals(
+        complexity_score=complexity_score,
+        domain_tag=domain_tag,
+        latency_requirement=latency_requirement,
+        token_budget=4096,
+        prompt_tokens_estimate=8,
+    )
+
+
+def test_rule_based_routes_legal_to_claude() -> None:
+    """Legal prompts should route to Claude under the rule-based matrix."""
+    strategy = RuleBasedStrategy(default_model_catalog())
+    decision = strategy.choose(_request(), _signals(0.5, DomainTag.LEGAL))
+    assert decision.chosen_model == "claude-3-5-sonnet"
+    assert "legal" in decision.rationale
+
+
+def test_rule_based_routes_complex_code_to_gpt4o() -> None:
+    """Complex code prompts should prefer GPT-4o."""
+    strategy = RuleBasedStrategy(default_model_catalog())
+    decision = strategy.choose(_request(), _signals(0.7, DomainTag.CODE))
+    assert decision.chosen_model == "gpt-4o"
+
+
+def test_rule_based_routes_simple_realtime_to_flash() -> None:
+    """Simple realtime prompts should prefer the low-latency flash model."""
+    strategy = RuleBasedStrategy(default_model_catalog())
+    decision = strategy.choose(
+        _request(), _signals(0.2, DomainTag.GENERAL, LatencyRequirement.REALTIME)
+    )
+    assert decision.chosen_model == "gemini-1.5-flash"
+
+
+def test_rule_based_honors_compatible_requested_model() -> None:
+    """An explicit, in-catalog model request should be honored."""
+    strategy = RuleBasedStrategy(default_model_catalog())
+    decision = strategy.choose(
+        _request(requested_model="kimi-k2"),
+        _signals(0.5, DomainTag.GENERAL),
+    )
+    assert decision.chosen_model == "kimi-k2"
+    assert decision.routing_strategy == RoutingStrategyName.RULE_BASED
+
+
+def test_rule_based_defaults_to_balanced_low_cost_model() -> None:
+    """A general prompt with no overrides should route to the balanced default."""
+    strategy = RuleBasedStrategy(default_model_catalog())
+    decision = strategy.choose(_request(), _signals(0.5, DomainTag.GENERAL))
+    assert decision.chosen_model == "gpt-4o-mini"
+
+
+def test_classifier_routes_high_complexity_to_sonnet() -> None:
+    """High classifier complexity should route to the top-quality model."""
+    strategy = ClassifierStrategy(default_model_catalog())
+    decision = strategy.choose(_request(), _signals(0.85, DomainTag.GENERAL))
+    assert decision.chosen_model == "claude-3-5-sonnet"
+
+
+def test_classifier_routes_simple_prompt_to_kimi() -> None:
+    """Low-complexity prompts should route to the cost-sensitive model."""
+    strategy = ClassifierStrategy(default_model_catalog())
+    decision = strategy.choose(_request(), _signals(0.2, DomainTag.GENERAL))
+    assert decision.chosen_model == "kimi-k2"
+
+
+def test_cost_optimal_forces_fallback_when_floor_unreachable() -> None:
+    """An unreachable quality floor should force the highest-quality fallback."""
+    strategy = CostOptimalStrategy(default_model_catalog(), quality_floor=1.0)
+    decision = strategy.choose(_request(), _signals(0.5, DomainTag.GENERAL))
+    assert decision.chosen_model == "claude-3-5-sonnet"
+    assert "quality floor forced" in decision.rationale
+
+
+def test_complexity_score_increases_with_instruction_hits() -> None:
+    """More instruction keywords should not decrease the complexity score."""
+    classifier = LogisticComplexityClassifier()
+    simple = classifier.predict_score(extract_prompt_features("Say hello."))
+    complex_prompt = classifier.predict_score(
+        extract_prompt_features("Analyze, debug, optimize, and compare these approaches.")
+    )
+    assert complex_prompt > simple


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The routing engine has good coverage for the medical rule-based path and the fallback chain, but several decision branches in `RuleBasedStrategy`, `ClassifierStrategy`, and `CostOptimalStrategy` were untested. This adds focused unit tests that pin down those branches so future changes to the routing matrices are caught.

## Changes

- `tests/test_strategy_coverage.py` (new): asserts the concrete model choices for
  - **rule-based**: legal → `claude-3-5-sonnet`, complex code → `gpt-4o`, simple realtime → `gemini-1.5-flash`, explicit compatible model honored, general default → `gpt-4o-mini`
  - **classifier**: high complexity → `claude-3-5-sonnet`, low complexity → `kimi-k2`
  - **cost-optimal**: unreachable quality floor forces the highest-quality fallback (`claude-3-5-sonnet`)
  - **complexity classifier**: score is monotonic in instruction-keyword hits

No production code is changed; this is test-only.

## Validation

Run in a Python 3.12 virtualenv created from `pip install -e ".[dev]"`:

- `ruff check src/ tests/` — all checks passed
- `mypy src/` — success, no issues
- `pytest tests/ -q` — 20 passed (was 11; +9 new tests)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97378c9f-721e-4ee3-83c6-94b82b3122c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

